### PR TITLE
fix: preserve round names when db_update upserts WC fixtures

### DIFF
--- a/wc2026/src/database.py
+++ b/wc2026/src/database.py
@@ -194,7 +194,7 @@ def upsert_fixture(fixture_data: dict[str, Any]) -> int:
                     team_b_name = EXCLUDED.team_b_name,
                     scheduled_at = EXCLUDED.scheduled_at,
                     venue_city = EXCLUDED.venue_city,
-                    round = EXCLUDED.round,
+                    round = COALESCE(wc2026_fixtures.round, EXCLUDED.round),
                     actual_home_goals = EXCLUDED.actual_home_goals,
                     actual_away_goals = EXCLUDED.actual_away_goals,
                     actual_outcome = EXCLUDED.actual_outcome,


### PR DESCRIPTION
Backfilled "round" of world cup games to have names like "Round of 32", "Round of 16", etc in Neon. The one-line db_update change will prevent that value from being overwritten every day. 