### PR TITLE
wc2026: fix all previous games parsing as 0-0 (goals from scores include)

### DIFF
--- a/wc2026/src/sportmonks_parser.py
+++ b/wc2026/src/sportmonks_parser.py
@@ -306,16 +306,18 @@ def parse_fixture_to_match_stats(
         extract_stat_value(fixture, opponent_id, STAT_TYPE_IDS["shots_on_target"])
     )
 
-    # AFC/CAF/OFC qualifiers on our SportMonks plan often return fixtures with
-    # scores but an empty xgfixture array. Fall back to CURRENT goals so the
-    # team still has a usable (goals-only) rating path.
-    if not _xgfixture_has_participant_stats(fixture, team_id):
-        scored = _goals_from_scores(fixture, team_id)
-        if scored is not None:
-            goals_scored = scored
-        conceded = _goals_from_scores(fixture, opponent_id)
-        if conceded is not None:
-            goals_conceded = conceded
+    # The ``scores`` include is authoritative for full-time goals. xgfixture
+    # goals rows can be missing while other stats are present (seen mid-WC in
+    # July 2026, when every match started parsing as 0-0 and flattened the
+    # ratings), and AFC/CAF/OFC qualifiers on our plan often have scores but
+    # an empty xgfixture array. Only keep the xgfixture goals value when the
+    # scores include has nothing for that participant.
+    scored = _goals_from_scores(fixture, team_id)
+    if scored is not None:
+        goals_scored = scored
+    conceded = _goals_from_scores(fixture, opponent_id)
+    if conceded is not None:
+        goals_conceded = conceded
 
     # Display-only.
     possession_pct = extract_stat_value(

--- a/wc2026/tests/test_sportmonks_parser.py
+++ b/wc2026/tests/test_sportmonks_parser.py
@@ -172,6 +172,70 @@ def test_parse_fixture_scores_fallback_when_xgfixture_empty():
     assert stats.xg_conceded == 0.0
 
 
+def test_parse_goals_from_scores_when_xgfixture_lacks_goals_rows():
+    """July 2026 regression: xgfixture carries xG but NO goals rows.
+
+    Every match parsed as 0-0 because the scores fallback only ran when
+    xgfixture was empty for the team. Goals must come from the scores
+    include whenever it has them.
+    """
+    fixture = {
+        "id": 19606900,
+        "starting_at": "2026-07-06 19:00:00",
+        "league_id": WC_FINALS_LEAGUE_ID,
+        "participants": [
+            {"id": 18710, "name": "Spain", "meta": {"location": "home"}},
+            {"id": 18726, "name": "Portugal", "meta": {"location": "away"}},
+        ],
+        "scores": [
+            {
+                "description": "CURRENT",
+                "participant_id": 18710,
+                "score": {"goals": 2, "participant": "home"},
+            },
+            {
+                "description": "CURRENT",
+                "participant_id": 18726,
+                "score": {"goals": 1, "participant": "away"},
+            },
+        ],
+        "xgfixture": [
+            {"participant_id": 18710, "type_id": STAT_TYPE_IDS["xg"], "data": {"value": 1.8}},
+            {"participant_id": 18726, "type_id": STAT_TYPE_IDS["xg"], "data": {"value": 0.9}},
+            # No goals rows at all -- the upstream regression.
+        ],
+    }
+    stats = parse_fixture_to_match_stats(
+        fixture, team_id=18710, opponent_fifa_points=1600.0
+    )
+    assert stats.goals_scored == 2
+    assert stats.goals_conceded == 1
+    assert stats.xg_created == pytest.approx(1.8)
+    assert stats.outcome == "W"
+
+
+def test_parse_scores_take_precedence_over_xgfixture_goals():
+    """When both sources carry goals, the scores include is authoritative."""
+    fixture = _minimal_fixture()  # xgfixture says 2-1
+    fixture["scores"] = [
+        {
+            "description": "CURRENT",
+            "participant_id": 1,
+            "score": {"goals": 4, "participant": "home"},
+        },
+        {
+            "description": "CURRENT",
+            "participant_id": 2,
+            "score": {"goals": 0, "participant": "away"},
+        },
+    ]
+    stats = parse_fixture_to_match_stats(
+        fixture, team_id=1, opponent_fifa_points=1200.0
+    )
+    assert stats.goals_scored == 4
+    assert stats.goals_conceded == 0
+
+
 def test_parse_venue_neutral_for_wc_finals():
     fixture = _minimal_fixture(league_id=WC_FINALS_LEAGUE_ID)
     # Team 1 is the "home" participant, but finals are always neutral.


### PR DESCRIPTION
## Problem
Since ~July 9, every WC match parses with 0 goals: the app's PREVIOUS GAMES cards all show 0-0 draws, and team ratings flatten (cron log: `baseline_goals_per_team=0.192 is implausibly low` on July 10 vs 2.727 on July 8), degrading every new prediction written to Neon.

## Cause
SportMonks stopped returning **goals** rows in the `xGFixture` include while still returning xG rows. The existing fallback to the `scores` include only ran when `xgfixture` was completely empty for the team — with xG rows present it never triggered, so goals defaulted to 0 for every match.

## Fix
`parse_fixture_to_match_stats` now always prefers full-time goals from the `scores` include (authoritative, still working — the fixtures cron reads it fine) and only keeps the `xgfixture` goals value when scores are absent (preserves the old behavior for fixtures without a scores include).

Added two tests: xgfixture-with-xG-but-no-goals-rows (the regression) and scores-precedence. `tests/test_sportmonks_parser.py`: 10 passed (2 pre-existing errors from the uncommitted `data/xg_diagnostic_responses.json` cache file, unrelated).

## After merging
Manually dispatch the **WC 2026 Refresh Predictions** workflow so the 3 quarterfinal predictions (written 2026-07-10 12:27 UTC from flattened ratings) are regenerated with real recent form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)