### PR TITLE
wc2026: add max_age_hours dispatch input to force re-predictions

### DIFF
--- a/.github/workflows/wc2026_refresh_predictions.yml
+++ b/.github/workflows/wc2026_refresh_predictions.yml
@@ -11,6 +11,10 @@ on:
         description: 'Predict fixtures kicking off within this many days (default 3). Use a larger value to backfill the opening slate.'
         required: false
         default: '3'
+      max_age_hours:
+        description: 'Re-predict fixtures whose prediction is older than this many hours (default 24). Use 0 to force a rewrite of every upcoming fixture in the window.'
+        required: false
+        default: '24'
 
 defaults:
   run:
@@ -39,4 +43,5 @@ jobs:
           NEON_DATABASE_URL: ${{ secrets.DB_URL }}
           SPORTMONKS_API_KEY: ${{ secrets.SPORTMONKS_API_KEY }}
           REFRESH_WITHIN_DAYS: ${{ github.event.inputs.within_days || '3' }}
+          REFRESH_MAX_AGE_HOURS: ${{ github.event.inputs.max_age_hours || '24' }}
         run: python scripts/cron_refresh_predictions.py

--- a/wc2026/scripts/cron_refresh_predictions.py
+++ b/wc2026/scripts/cron_refresh_predictions.py
@@ -44,6 +44,10 @@ def main() -> int:
     # fixtures further out than the daily 3-day horizon (e.g. an opening-slate
     # populate before the tournament starts). Scheduled runs leave it at 3.
     within_days = int(os.getenv("REFRESH_WITHIN_DAYS", "3"))
+    # Also env-overridable: how old a prediction must be before it is
+    # re-predicted. A manual dispatch with 0 forces a rewrite of every
+    # upcoming fixture in the window (e.g. after a model or data fix).
+    max_age_hours = int(os.getenv("REFRESH_MAX_AGE_HOURS", "24"))
     # Re-fetch qualifier + WC-finals matches each run so the 5-match window
     # picks up newly played World Cup fixtures (league 732).
     force_pool_refresh = os.getenv("FORCE_POOL_REFRESH", "1").lower() not in (
@@ -54,7 +58,9 @@ def main() -> int:
 
     try:
         pool = bootstrap_tournament_pool(force_refresh=force_pool_refresh)
-        fixtures = get_fixtures_needing_prediction(within_days=within_days)
+        fixtures = get_fixtures_needing_prediction(
+            within_days=within_days, prediction_max_age_hours=max_age_hours
+        )
     except DatabaseError as exc:
         print(f"ERROR: setup failed: {exc}")
         return 1


### PR DESCRIPTION
Adds a `max_age_hours` input to the WC 2026 Refresh Predictions manual dispatch (env `REFRESH_MAX_AGE_HOURS`), passed to `get_fixtures_needing_prediction`. Default 24 keeps scheduled behavior identical; `0` forces a rewrite of every upcoming fixture in the window.

Needed now to regenerate the Norway–England and Argentina–Switzerland predictions (written 2026-07-10 12:27 UTC from flattened ratings) without waiting for the 24h staleness window:

```
gh workflow run wc2026_refresh_predictions.yml -R yachachli/db_update -f max_age_hours=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)