### PR TITLE
Add NFL PropGPT season-ops cron (nfl_model_v2)

### DIFF
--- a/.github/workflows/nfl_propgpt.yml
+++ b/.github/workflows/nfl_propgpt.yml
@@ -1,0 +1,89 @@
+name: NFL PropGPT season ops
+
+# Checks out zernerdoescode/nfl-propgpt-model and runs the weekly DAG
+# against Neon schema nfl_model_v2. Does not replace nfl-update.yml (v3_nfl_*).
+
+on:
+  schedule:
+    - cron: "0 15 * * 2"
+    - cron: "0 15 * * 4"
+    - cron: "0 15 * * 6"
+    - cron: "0 14 * * 0"
+  workflow_dispatch:
+    inputs:
+      day:
+        description: DAG to run
+        type: choice
+        options: [auto, tuesday, thursday, saturday, sunday, all]
+        default: auto
+
+jobs:
+  weekly:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      TANK01_API_KEY: ${{ secrets.TANK01_API_KEY }}
+      RAPIDAPI_KEY: ${{ secrets.RAPIDAPI_KEY }}
+      DB_URL: ${{ secrets.DB_URL }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      DB_NAME: ${{ secrets.DB_NAME }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      DB_HOST: ${{ secrets.DB_HOST }}
+      DB_SCHEMA: ${{ secrets.DB_SCHEMA }}
+      LOG_LEVEL: INFO
+    steps:
+      - name: Checkout db_update
+        uses: actions/checkout@v4
+
+      - name: Checkout nfl-propgpt-model
+        uses: actions/checkout@v4
+        with:
+          repository: zernerdoescode/nfl-propgpt-model
+          token: ${{ secrets.NFL_MODEL_TOKEN }}
+          path: nfl-propgpt-model
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Resolve Neon + Tank01 env
+        run: |
+          set -euo pipefail
+          if [ -z "${TANK01_API_KEY:-}" ] && [ -n "${RAPIDAPI_KEY:-}" ]; then
+            echo "TANK01_API_KEY=${RAPIDAPI_KEY}" >> "$GITHUB_ENV"
+          fi
+          if [ -z "${DB_URL:-}" ] && [ -n "${DATABASE_URL:-}" ]; then
+            echo "DB_URL=${DATABASE_URL}" >> "$GITHUB_ENV"
+          fi
+          echo "DB_SCHEMA=${DB_SCHEMA:-nfl_model_v2}" >> "$GITHUB_ENV"
+
+      - name: Restore Tank01 / run-state cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            nfl-propgpt-model/data/raw_cache
+            nfl-propgpt-model/data/run_state
+          key: nfl-propgpt-${{ github.run_id }}
+          restore-keys: |
+            nfl-propgpt-
+
+      - name: Install model
+        working-directory: nfl-propgpt-model
+        run: pip install -e .
+
+      - name: Migrate nfl_model_v2
+        working-directory: nfl-propgpt-model
+        run: python -m alembic upgrade head
+
+      - name: weekly_run
+        env:
+          NFL_MODEL_ROOT: ${{ github.workspace }}/nfl-propgpt-model
+        run: |
+          set -euo pipefail
+          DAY="${{ github.event.inputs.day || 'auto' }}"
+          EXTRA=(--skip-retrain)
+          if [ "$DAY" != "auto" ]; then
+            EXTRA+=(--day "$DAY")
+          fi
+          python -m nfl_propgpt_update "${EXTRA[@]}"

--- a/nfl_propgpt_update/README.md
+++ b/nfl_propgpt_update/README.md
@@ -1,0 +1,30 @@
+# nfl_propgpt_update
+
+Cron entry for the v2 NFL model (`zernerdoescode/nfl-propgpt-model`).
+Writes `nfl_model_v2.*` on the shared Neon database.
+
+The legacy `nfl-update.py` job is unchanged — it still refreshes `v3_nfl_*`.
+This package is the new schema.
+
+## Schedule
+
+| UTC cron | Local (PT) | DAG |
+| --- | --- | --- |
+| `0 15 * * 2` | Tue 08:00 | box scores, grade, roster, tWAR, PGRS, DODES, T-120h |
+| `0 15 * * 4` | Thu 08:00 | T-72h, injuries, early `predict_week`, odds |
+| `0 15 * * 6` | Sat 08:00 | T-24h, final injuries, primary card |
+| `0 14 * * 0` | Sun 07:00 | T-4h, props, lock predictions |
+
+Manual run: Actions → **NFL PropGPT season ops** → Run workflow.
+
+## Secrets on `yachachli/db_update`
+
+| Secret | Used for |
+| --- | --- |
+| `NFL_MODEL_TOKEN` | PAT (or fine-grained token) with **read** on `zernerdoescode/nfl-propgpt-model` |
+| `DATABASE_URL` or `DB_URL` | Neon URI (`?sslmode=require`). `DB_USER`/`DB_PASSWORD`/`DB_HOST`/`DB_NAME` also work |
+| `TANK01_API_KEY` or `RAPIDAPI_KEY` | Tank01 / RapidAPI key |
+| `DB_SCHEMA` | optional, default `nfl_model_v2` |
+
+The same DAG also lives in the model repo (`.github/workflows/season-ops.yml`)
+and can run there with only `TANK01_API_KEY` + `DB_URL`.

--- a/nfl_propgpt_update/__init__.py
+++ b/nfl_propgpt_update/__init__.py
@@ -1,0 +1,1 @@
+"""Cron wrapper that runs nfl-propgpt-model weekly_run against Neon."""

--- a/nfl_propgpt_update/__main__.py
+++ b/nfl_propgpt_update/__main__.py
@@ -1,0 +1,49 @@
+"""Map db_update Neon secrets onto ``scripts/weekly_run.py``.
+
+Expected checkout layout::
+
+    db_update/                  # this repo
+    nfl-propgpt-model/          # zernerdoescode/nfl-propgpt-model
+
+Env (any one of the DB forms is enough):
+
+    TANK01_API_KEY or RAPIDAPI_KEY
+    DB_URL or DATABASE_URL or DB_USER + DB_PASSWORD + DB_HOST + DB_NAME
+    DB_SCHEMA   (default nfl_model_v2)
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def neon_url() -> str:
+    if os.environ.get("DB_URL"):
+        return os.environ["DB_URL"]
+    if os.environ.get("DATABASE_URL"):
+        return os.environ["DATABASE_URL"]
+    user = os.environ["DB_USER"]
+    password = os.environ["DB_PASSWORD"]
+    host = os.environ["DB_HOST"]
+    name = os.environ["DB_NAME"]
+    return f"postgresql://{user}:{password}@{host}/{name}?sslmode=require"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not os.environ.get("TANK01_API_KEY"):
+        os.environ["TANK01_API_KEY"] = os.environ.get("RAPIDAPI_KEY") or ""
+    os.environ["DB_URL"] = neon_url()
+    os.environ.setdefault("DB_SCHEMA", "nfl_model_v2")
+    root = Path(os.environ.get("NFL_MODEL_ROOT", "nfl-propgpt-model")).resolve()
+    script = root / "scripts" / "weekly_run.py"
+    if not script.is_file():
+        raise SystemExit(f"nfl-propgpt-model not checked out at {root}")
+    return subprocess.call([sys.executable, str(script), *args], cwd=root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Summary
- Adds a Tuesday / Thursday / Saturday / Sunday GitHub Actions cron that checks out `zernerdoescode/nfl-propgpt-model` and runs `weekly_run.py` against Neon schema `nfl_model_v2`.
- Leaves the existing `nfl-update.yml` job alone — that one still refreshes `v3_nfl_*`.

## Secrets
- `NFL_MODEL_TOKEN` — PAT with read access to the private model repo
- `DATABASE_URL` or `DB_URL` (or the existing `DB_*` quartet)
- `TANK01_API_KEY` or the existing `RAPIDAPI_KEY`

## Test plan
- [ ] Add `NFL_MODEL_TOKEN` on this repo
- [ ] Actions → NFL PropGPT season ops → Run workflow → tuesday
- [ ] Confirm `nfl_model_v2` tables update and `v3_nfl_*` is untouched
